### PR TITLE
Small fix for PHP < 5.4

### DIFF
--- a/qtranslate_services.php
+++ b/qtranslate_services.php
@@ -260,7 +260,7 @@ function qts_save() {
 }
 
 function qts_cleanup($var, $action) {
-	if( !is_array($var) ) $var = [];
+	if( !is_array($var) ) $var = array();
 	switch($action) {
 		case QTS_GET_SERVICES:
 			foreach($var as $service_id => $service) {


### PR DESCRIPTION
In my "cleanup" patch I accidentally wrote code that's only compatible with PHP >= 5.4, but unfortunately, some people are still using 5.3.