### PR TITLE
Sanitize inputs

### DIFF
--- a/qtranslate_configuration.php
+++ b/qtranslate_configuration.php
@@ -541,12 +541,12 @@ function qtranxf_updateSetting($var, $type = QTX_STRING) {
 			if($type == QTX_URL) $_POST[$var] = trailingslashit($_POST[$var]);
 			else if($type == QTX_LANGUAGE && !qtranxf_isEnabled($_POST[$var])) return false;
 			if($q_config[$var] == $_POST[$var]) return false;
-			$q_config[$var] = $_POST[$var];
+			$q_config[$var] = sanitize_text_field($_POST[$var]);
 			update_option('qtranslate_'.$var, $q_config[$var]);
 			return true;
 		case QTX_ARRAY:
 			if(!isset($_POST[$var])) return false;
-			$val=preg_split('/[\s,]+/',$_POST[$var],null,PREG_SPLIT_NO_EMPTY);
+			$val=preg_split('/[\s,]+/',sanitize_text_field($_POST[$var]),null,PREG_SPLIT_NO_EMPTY);
 			if( qtranxf_array_compare($q_config[$var],$val) ) return false;
 			$q_config[$var] = $val;
 			update_option('qtranslate_'.$var, $q_config[$var]);

--- a/qtranslate_configuration.php
+++ b/qtranslate_configuration.php
@@ -782,24 +782,24 @@ function qtranxf_conf() {
 		}
 		if($error=='') {
 			// everything is fine, insert language
-			$q_config['language_name'][$_POST['language_code']] = $_POST['language_name'];
-			$q_config['flag'][$_POST['language_code']] = $_POST['language_flag'];
-			$q_config['locale'][$_POST['language_code']] = $_POST['language_locale'];
-			$q_config['date_format'][$_POST['language_code']] = $_POST['language_date_format'];
-			$q_config['time_format'][$_POST['language_code']] = $_POST['language_time_format'];
-			$q_config['not_available'][$_POST['language_code']] = $_POST['language_na_message'];
+			$q_config['language_name'][$_POST['language_code']] = sanitize_text_field($_POST['language_name']);
+			$q_config['flag'][$_POST['language_code']] = sanitize_text_field($_POST['language_flag']);
+			$q_config['locale'][$_POST['language_code']] = sanitize_text_field($_POST['language_locale']);
+			$q_config['date_format'][$_POST['language_code']] = sanitize_text_field($_POST['language_date_format']);
+			$q_config['time_format'][$_POST['language_code']] = sanitize_text_field($_POST['language_time_format']);
+			$q_config['not_available'][$_POST['language_code']] = sanitize_text_field($_POST['language_na_message']);
 		}
 		if($error!=''||isset($_GET['edit'])) {
 			// get old values in the form
-			$original_lang = $_POST['original_lang'];
-			$language_code = $_POST['language_code'];
-			$language_name = $_POST['language_name'];
-			$language_locale = $_POST['language_locale'];
-			$language_date_format = $_POST['language_date_format'];
-			$language_time_format = $_POST['language_time_format'];
-			$language_na_message = $_POST['language_na_message'];
-			$language_flag = $_POST['language_flag'];
-			$language_default = $_POST['language_default'];
+			$original_lang = sanitize_text_field($_POST['original_lang']);
+			$language_code = sanitize_text_field($_POST['language_code']);
+			$language_name = sanitize_text_field($_POST['language_name']);
+			$language_locale = sanitize_text_field($_POST['language_locale']);
+			$language_date_format = sanitize_text_field($_POST['language_date_format']);
+			$language_time_format = sanitize_text_field($_POST['language_time_format']);
+			$language_na_message = sanitize_text_field($_POST['language_na_message']);
+			$language_flag = sanitize_text_field($_POST['language_flag']);
+			$language_default = sanitize_text_field($_POST['language_default']);
 		}
 	} elseif(isset($_GET['convert'])){
 		// update language tags


### PR DESCRIPTION
After doing a security review of this plugin I found that site/blog-admins are able to include javascript tags and other HTML markup in text-fields that could allow the inclusion of malicious javascript on every page, e.g. 

Language Name:  `English <script>alert(document.cookie);</script>`

While site-admins might be trusted on single-site installations, on multi-site installations the owners/admins of individual sites cannot necessarily be trusted. This pull-request runs the user-inputs in the configuration screens through WP's built-in input-validation functions. For more information, see: http://codex.wordpress.org/Data_Validation#Input_Validation