### PR TITLE
Load translations manually in the widget constructor

### DIFF
--- a/qtranslate_widget.php
+++ b/qtranslate_widget.php
@@ -46,6 +46,9 @@ transition: 1s ease opacity;
 
 class qTranslateXWidget extends WP_Widget {
 	function qTranslateXWidget() {
+		// load plugin translations manually here, because otherwise the translations are not available inside the constructor
+		load_plugin_textdomain('qtranslate', false, dirname(plugin_basename( __FILE__ )).'/lang');
+ 
 		$widget_ops = array('classname' => 'qtranxs_widget', 'description' => __('Allows your visitors to choose a Language.', 'qtranslate') );
 		$this->WP_Widget('qtranslate', __('qTranslate Language Chooser', 'qtranslate'), $widget_ops);
 		//add_action('qtranslate_head_add_css',array($this,'head_add_css'));


### PR DESCRIPTION
otherwise the translations are not available inside the constructor.

Fixes #43