### PR TITLE
Bugfix for highlighting translatable fields

### DIFF
--- a/admin/js/common.js
+++ b/admin/js/common.js
@@ -369,12 +369,6 @@ var qTranslateX=function(pg)
 			//c('updateTinyMCE:wpautop:'+text);
 		}
 		ed.setContent(text,{format: 'html'});
-
-		/**
-		 * Highlighting the translatable fields
-		 * Since 3.2-b3
-		*/
-		ed.getContainer().className += ' qtranxs-translatable';
 	}
 
 	onTabSwitch=function()
@@ -595,6 +589,14 @@ var qTranslateX=function(pg)
 					h.contents[h.lang] = h.contentField.value;
 					updateFusedValueHooked(h);
 				});
+
+            /**
+             * Highlighting the translatable fields
+             * Since 3.2-b3
+            */
+            ed.getContainer().className += ' qtranxs-translatable';
+            ed.getElement().className += ' qtranxs-translatable';
+
 			return h;
 		}
 


### PR DESCRIPTION
* Textarea was not highlighted in Text mode, and in Visual mode only if it was already in Visual mode on page load
* Also fixes the problem of the class name being added multiple times while switching languages

Related to issue #30