### PR TITLE
Fixed flags directory breaking when using custom directory for plugins

### DIFF
--- a/qtranslate_configuration.php
+++ b/qtranslate_configuration.php
@@ -1063,9 +1063,9 @@ function qtranxf_conf() {
 			<tr valign="top">
 				<th scope="row"><?php _e('Flag Image Path', 'qtranslate');?></th>
 				<td>
-					<?php echo trailingslashit(WP_CONTENT_URL); ?><input type="text" name="flag_location" id="flag_location" value="<?php echo $q_config['flag_location']; ?>" style="width:100%"/>
+					<input type="text" name="flag_location" id="flag_location" value="<?php echo $q_config['flag_location']; ?>" style="width:100%"/>
 					<br/>
-					<small><?php printf(__('Path to the flag images under wp-content, with trailing slash. (Default: %s, clear the value above to reset it to the default)', 'qtranslate'), qtranxf_flag_location_default()); ?></small>
+					<small><?php printf(__('Path to the flag images, with trailing slash. (Default: %s, clear the value above to reset it to the default)', 'qtranslate'), qtranxf_flag_location_default()); ?></small>
 				</td>
 			</tr>
 			<tr valign="top">

--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -520,13 +520,12 @@ function qtranxf_init() {
 
 function qtranxf_flag_location() {
 	global $q_config;
-	return trailingslashit(WP_CONTENT_URL).$q_config['flag_location'];
+	return $q_config['flag_location'];
 }
 
 function qtranxf_flag_location_default() {
 	//$q_config['flag_location'] = 'plugins/qtranslate-x/flags/';
-	$plugindir = dirname(plugin_basename( __FILE__ ));
-	return 'plugins/'.$plugindir.'/flags/';
+	return plugin_dir_url(__FILE__).'flags/';
 }
 
 function qtranxf_load_option_flag_location($nm) {


### PR DESCRIPTION
This has only one caveat. The users will need to add `wp-content` to
the flags directory themselves but it will give users much more
flexibility on where they want the flags directory to be.