### PR TITLE
Added an option to configure whether or not to highlight translatable fields

### DIFF
--- a/qtranslate.php
+++ b/qtranslate.php
@@ -139,6 +139,11 @@ define('QTX_EDITOR_MODE_LSB', 0);//Language Switching Buttons
 define('QTX_EDITOR_MODE_RAW', 1);
 define('QTX_EDITOR_MODE_SINGLGE', 2);
 
+define('QTX_HIGHLIGHT_MODE_NONE', 0);
+define('QTX_HIGHLIGHT_MODE_LEFT_BORDER', 1);
+define('QTX_HIGHLIGHT_MODE_BORDER', 2);
+define('QTX_HIGHLIGHT_MODE_CUSTOM_CSS', 9);
+
 define('QTX_COOKIE_NAME_FRONT','qtrans_front_language');
 define('QTX_COOKIE_NAME_ADMIN','qtrans_admin_language');
 
@@ -553,6 +558,8 @@ function qtranxf_set_config_default()
 	$q_config['use_secure_cookie'] = false;
 	$q_config['header_css_on'] = true;
 
+	$q_config['highlight_mode'] = QTX_HIGHLIGHT_MODE_LEFT_BORDER;
+
 	$q_config = apply_filters('qtranslate_config_default', $q_config);
 }
 qtranxf_set_config_default();
@@ -560,6 +567,7 @@ qtranxf_set_config_default();
 require_once(dirname(__FILE__)."/qtranslate_utils.php");
 require_once(dirname(__FILE__)."/qtranslate_core.php");
 require_once(dirname(__FILE__)."/qtranslate_widget.php");
+require_once(dirname(__FILE__)."/qtranslate_user_options.php");
 
 if(is_admin()){
 	require_once(dirname(__FILE__).'/admin/activation_hook.php');

--- a/qtranslate_configuration.css
+++ b/qtranslate_configuration.css
@@ -165,12 +165,3 @@
   opacity: 1;
 }
 */
-
-/* Highlighting the translatable fields */
-/*
-input.qtranxs-translatable,
-textarea.qtranxs-translatable,
-div.qtranxs-translatable {
-	box-shadow: -3px 0 #333;
-}
-*/

--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -610,6 +610,8 @@ function qtranxf_loadConfig() {
 	qtranxf_load_option_flag_location('flag_location');
 
 	qtranxf_load_option('editor_mode');
+	qtranxf_load_option('highlight_mode');
+	qtranxf_load_option('highlight_mode_custom_css');
 
 	qtranxf_load_option_array('custom_fields');
 	qtranxf_load_option_array('custom_field_classes');

--- a/qtranslate_user_options.php
+++ b/qtranslate_user_options.php
@@ -1,0 +1,40 @@
+<?php
+add_action( 'show_user_profile', 'qtranxf_show_extra_profile_fields' );
+add_action( 'edit_user_profile', 'qtranxf_show_extra_profile_fields' );
+
+function qtranxf_show_extra_profile_fields( $user ) {
+	global $q_config;
+	if ( $q_config['highlight_mode'] != QTX_HIGHLIGHT_MODE_NONE ) { ?>
+
+		<h3><?php _e( 'Translation options', 'qtranslate' ) ?></h3>
+
+		<table class="form-table">
+
+			<tr>
+				<th><label for="qtranslate_highlight_disabled"><?php _e( 'Do not highlight fields', 'qtranslate' ) ?></label></th>
+
+				<td>
+					<input type="checkbox" value="1" name="qtranslate_highlight_disabled" id="qtranslate_highlight_disabled" <?php checked( get_the_author_meta( 'qtranslate_highlight_disabled', $user->ID ) ); ?> /><br/>
+					<span class="description"><?php _e( 'If you do not like that the translatable fields are highlighted, you can disable that option here', 'qtranslate' ) ?></span>
+				</td>
+			</tr>
+
+		</table>
+	<?php
+	}
+}
+
+add_action( 'personal_options_update', 'qtranxf_save_extra_profile_fields' );
+add_action( 'edit_user_profile_update', 'qtranxf_save_extra_profile_fields' );
+
+function qtranxf_save_extra_profile_fields( $user_id ) {
+	global $q_config;
+
+	if ( ! current_user_can( 'edit_user', $user_id ) ) {
+		return false;
+	}
+
+	if ( $q_config['highlight_mode'] != QTX_HIGHLIGHT_MODE_NONE ) {
+		update_user_meta( $user_id, 'qtranslate_highlight_disabled', $_POST['qtranslate_highlight_disabled'] );
+	}
+}

--- a/qtranslate_utils.php
+++ b/qtranslate_utils.php
@@ -583,3 +583,13 @@ function qtranxf_getSortedLanguages($reverse = false) {
 function qtranxf_can_redirect() {
 	return !defined('WP_ADMIN') && !defined('DOING_AJAX') && !defined('WP_CLI') && !defined('DOING_CRON') && empty($_POST);
 }
+
+/**
+ * Get the currently selected admin color scheme (to be used for generated CSS)
+ * @return array
+ */
+function qtranxf_get_user_admin_color() {
+	global $_wp_admin_css_colors;
+	$user_admin_color = get_user_meta( get_current_user_id(), 'admin_color', true );
+	return $_wp_admin_css_colors[$user_admin_color]->colors;
+}


### PR DESCRIPTION
* Currently there are two styles (border around or border left)
* Both options use the colors from the admin color profile that the current user has selected
* Additionally, custom CSS can be entered. Upon saving, the custom CSS is set to the last option used, so it can be easily customized
* The highlighting can be disabled on a per-user level (on the user's profile page)
Related to issue #30