### PR TITLE
Display error message if manual gettext-update fails

### DIFF
--- a/admin/qtx_configuration.php
+++ b/admin/qtx_configuration.php
@@ -871,8 +871,14 @@ function qtranxf_conf() {
 
 		qtranxf_updateSetting('header_css', QTX_STRING, qtranxf_front_header_css_default());
 
-		if(isset($_POST['update_mo_now']) && $_POST['update_mo_now']=='1' && qtranxf_updateGettextDatabases(true))
-			$message[] = __('Gettext databases updated.', 'qtranslate');
+		if ( isset( $_POST['update_mo_now'] ) && $_POST['update_mo_now'] == '1' ) {
+			$result = qtranxf_updateGettextDatabases( true );
+			if ( $result === true ) {
+				$message[] = __( 'Gettext databases updated.', 'qtranslate' );
+			} elseif ( is_wp_error( $result ) ) {
+				$message[] = __( 'Gettext databases <strong>not</strong> updated:', 'qtranslate' ) . ' ' . $result->get_error_message();
+			}
+		}
 
 		$import_migration = preg_grep( '/import/', $_POST );
 		foreach($import_migration as $key => $value){

--- a/admin/qtx_update_gettext_db.php
+++ b/admin/qtx_update_gettext_db.php
@@ -15,8 +15,11 @@ function qtranxf_updateGettextDatabases($force = false, $only_for_language = '')
 	require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 	require_once ABSPATH . 'wp-admin/includes/file.php';
 	include( ABSPATH . WPINC . '/version.php' ); // include an unmodified $wp_version
+	$result = translations_api( 'core', array( 'version' => $wp_version ));
 
-	if ( ! is_wp_error( $result = translations_api( 'core', array( 'version' => $wp_version ) ) ) ) {
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	} else {
 		foreach ( $result['translations'] as $translation ) {
 			$locale = substr($translation['language'], 0, 2);
 			if (
@@ -33,6 +36,4 @@ function qtranxf_updateGettextDatabases($force = false, $only_for_language = '')
 		}
 		return true;
 	}
-	else
-		return false;
 }

--- a/admin/qtx_update_gettext_db.php
+++ b/admin/qtx_update_gettext_db.php
@@ -15,21 +15,24 @@ function qtranxf_updateGettextDatabases($force = false, $only_for_language = '')
 	require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 	require_once ABSPATH . 'wp-admin/includes/file.php';
 	include( ABSPATH . WPINC . '/version.php' ); // include an unmodified $wp_version
-	$result = translations_api( 'core', array( 'version' => $wp_version ) );
 
-	foreach ( $result['translations'] as $translation ) {
-		$locale = substr($translation['language'], 0, 2);
-		if (
-			isset( $q_config['locale'][$locale] )
-			&& $q_config['locale'][$locale] == $translation['language']
-			&& qtranxf_isEnabled($locale)
-		) {
-			$translation = (object) $translation;
-			$skin              = new Automatic_Upgrader_Skin;
-			$upgrader          = new Language_Pack_Upgrader( $skin );
-			$translation->type = 'core';
-			$result            = $upgrader->upgrade( $translation, array( 'clear_update_cache' => false ) );
+	if ( ! is_wp_error( $result = translations_api( 'core', array( 'version' => $wp_version ) ) ) ) {
+		foreach ( $result['translations'] as $translation ) {
+			$locale = substr($translation['language'], 0, 2);
+			if (
+				isset( $q_config['locale'][$locale] )
+				&& $q_config['locale'][$locale] == $translation['language']
+				&& qtranxf_isEnabled($locale)
+			) {
+				$translation = (object) $translation;
+				$skin              = new Automatic_Upgrader_Skin;
+				$upgrader          = new Language_Pack_Upgrader( $skin );
+				$translation->type = 'core';
+				$result            = $upgrader->upgrade( $translation, array( 'clear_update_cache' => false ) );
+			}
 		}
+		return true;
 	}
-	return true;
+	else
+		return false;
 }


### PR DESCRIPTION
This is an addition to #105.
The WPError is forwarded to the caller and the error message is displayed on the admin interface. This should make it easier to debug what went wrong.