### PR TITLE
I added brackets ([]) to exclusion list of replacement by regex, it's be...

### DIFF
--- a/qtranslate_utils.php
+++ b/qtranslate_utils.php
@@ -319,7 +319,7 @@ function qtranxf_del_query_arg(&$query, $key){
 */
 function qtranxf_sanitize_url($url)
 {
-	$url = preg_replace('|[^a-z0-9-~+_.?#=!&;,/:%@$\|*\'()\\x80-\\xff]|i', '', $url);
+	$url = preg_replace('|[^a-z0-9-~+_.?#=!&;,/:%@$\|*\'()\[\]\\x80-\\xff]|i', '', $url);
 	$strip = array('%0d', '%0a', '%0D', '%0A');
 	$count;
 	do{ $url = str_replace( $strip, '', $url, $count ); } while($count);


### PR DESCRIPTION
I added brackets ([]) to exclusion list of replacement by regex, it's because some of request parameters has type of array.
For example: http://example.com/?date_query[after]=2015-01-01&date_query[before]=2015-01-15
See also: http://wp-api.org/#posts_retrieve-posts