### PR TITLE
Fixed a bug that translated also external URLs when they are subdomains ...

### DIFF
--- a/qtranslate_utils.php
+++ b/qtranslate_utils.php
@@ -366,7 +366,7 @@ function qtranxf_external_host_ex($host,$homeinfo){
 	//$homehost = qtranxf_get_home_info()['host'];
 	switch($q_config['url_mode']){
 		case QTX_URL_QUERY: return $homeinfo['host'] != $host;
-		case QTX_URL_PATH:
+		case QTX_URL_PATH: return $homeinfo['host'] != $host;
 		case QTX_URL_DOMAIN: return !qtranxf_endsWith($host,$homeinfo['host']);
 		case QTX_URL_DOMAINS:
 			foreach($q_config['domains'] as $lang => $h){


### PR DESCRIPTION
...and the configuration is in the path mode.

For further information, check the issue: https://github.com/qTranslate-Team/qtranslate-x/issues/148