### PR TITLE
Bug in type of key

### DIFF
--- a/admin/qtx_activation_hook.php
+++ b/admin/qtx_activation_hook.php
@@ -370,7 +370,7 @@ function qtranxf_admin_notices_next_thanks()
 	echo '<ul style="list-style: square; list-style-position: inside;"><li>';
 	printf(__('%sUse Support Forum%s to ask a question.', 'qtranslate'), '<a href="https://wordpress.org/support/plugin/qtranslate-x" target="_blank">', '</a>');
 	echo '</li><li>';
-	printf(_x('%sVisit%s %s website.', 'qtranslate'), '<a href="https://qtranslatexteam.wordpress.com/" target="_blank">', '</a>', '"<a href="https://qtranslatexteam.wordpress.com/about/" target="_blank">qTranslate-X explained</a>"');
+	printf(__('%sVisit%s %s website.', 'qtranslate'), '<a href="https://qtranslatexteam.wordpress.com/" target="_blank">', '</a>', '"<a href="https://qtranslatexteam.wordpress.com/about/" target="_blank">qTranslate-X explained</a>"');
 	echo '</li><li>';
 	printf(__('%sShare a new idea%s with our community.', 'qtranslate'), '<a href="https://qtranslatexteam.wordpress.com/contact-us/"  target="_blank">', '</a>');
 	echo '</li><li>';

--- a/lang/qtranslate.pot
+++ b/lang/qtranslate.pot
@@ -101,7 +101,6 @@ msgstr ""
 
 #: admin/qtx_activation_hook.php:373
 #, php-format
-msgctxt "qtranslate"
 msgid "%sVisit%s %s website."
 msgstr ""
 


### PR DESCRIPTION
There is no context string, 'qtranslate' is probably just the textdomain, so this is just a simple __(), or else it won't get translated.