### PR TITLE
Replace usages of WP_CONTENT_URL with content_url() to get the correct protocol.

### DIFF
--- a/admin/qtx_configuration.php
+++ b/admin/qtx_configuration.php
@@ -329,7 +329,7 @@ echo ' '; printf(__('Please, read %sIntegration Guide%s for more information.', 
 			<tr valign="top">
 				<th scope="row"><?php _e('Flag Image Path', 'qtranslate') ?></th>
 				<td>
-					<?php echo trailingslashit(WP_CONTENT_URL) ?><input type="text" name="flag_location" id="flag_location" value="<?php echo $q_config['flag_location']; ?>" style="width:100%"/>
+					<?php echo trailingslashit(content_url()) ?><input type="text" name="flag_location" id="flag_location" value="<?php echo $q_config['flag_location']; ?>" style="width:100%"/>
 					<p class="qtranxs_notes"><?php printf(__('Path to the flag images under wp-content, with trailing slash. (Default: %s, clear the value above to reset it to the default)', 'qtranslate'), qtranxf_flag_location_default()) ?></p>
 				</td>
 			</tr>
@@ -609,7 +609,7 @@ echo ' '; printf(__('Please, read %sIntegration Guide%s for more information.', 
 	$flag_location_url = qtranxf_flag_location();
 	$flag_location_dir = trailingslashit(WP_CONTENT_DIR).$q_config['flag_location'];
 	$flag_location_url_def = content_url(qtranxf_flag_location_default());
-	//trailingslashit(WP_CONTENT_URL).'/plugins/'.basename(dirname(QTRANSLATE_FILE)).'/flags/';
+	//trailingslashit(content_url()).'/plugins/'.basename(dirname(QTRANSLATE_FILE)).'/flags/';
 	foreach($language_names as $lang => $language){ if($lang=='code') continue;
 		$flag = $flags[$lang];
 		if(file_exists($flag_location_dir.$flag)){

--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -497,7 +497,7 @@ function qtranxf_front_header_css_default(){
 
 function qtranxf_flag_location() {
 	global $q_config;
-	return trailingslashit(WP_CONTENT_URL).$q_config['flag_location'];
+	return trailingslashit(content_url()).$q_config['flag_location'];
 }
 
 function qtranxf_flag_location_default() {


### PR DESCRIPTION
Fixes mixed-content warnings in browsers for the flags when viewing the page over HTTPS.

*(See wp.org support thread ["Language flags break https in the admin page"](https://wordpress.org/support/topic/language-flags-break-https-in-the-admin-page?replies=5))*

I've tested it on my test server and the flag images are now loaded over HTTPS as well (both in the language switcher and the admin page).