### PR TITLE
Update qtranslate_widget.php

### DIFF
--- a/qtranslate_widget.php
+++ b/qtranslate_widget.php
@@ -29,7 +29,7 @@ class qTranslateXWidget extends WP_Widget {
 
 	function qTranslateXWidget() {
 		$widget_ops = array('classname' => 'qtranxs_widget', 'description' => __('Allows your visitors to choose a Language.', 'qtranslate') );
-		$this->WP_Widget('qtranslate', __('qTranslate Language Chooser', 'qtranslate'), $widget_ops);
+		$this->__construct('qtranslate', __('qTranslate Language Chooser', 'qtranslate'), $widget_ops);
 	}
 
 	function widget($args, $instance) {


### PR DESCRIPTION
PHP Notice: The called constructor method for WP_Widget is deprecated since version 4.3.0! Use __construct() instead.

@see deprecated WP_Widget #202