### PR TITLE
Handle the CSRF vulnerability

### DIFF
--- a/admin/qtx_admin_utils.php
+++ b/admin/qtx_admin_utils.php
@@ -823,7 +823,7 @@ function qtranxf_config_add_form( &$page_config, $nm){
 }
 
 /**
- * @since 3.4.1
+ * @since 3.4.5
  * check the WP Nonce - OK if POST is empty
  * @link https://codex.wordpress.org/Function_Reference/wp_nonce_field#Examples
  * @param  string $my_action   Name specified when generating the nonce

--- a/admin/qtx_admin_utils.php
+++ b/admin/qtx_admin_utils.php
@@ -338,7 +338,7 @@ function qtranxf_get_term_joined($obj,$taxonomy=null) {
 			//'[:'.$q_config['language'].']'.$obj->name
 			$obj->name = qtranxf_join_b($q_config['term_name'][$obj->name]);
 			//qtranxf_dbg_log('qtranxf_get_term_joined: object:',$obj);
-		} 
+		}
 	}elseif(isset($q_config['term_name'][$obj])) {
 		$obj = qtranxf_join_b($q_config['term_name'][$obj]);
 		//'[:'.$q_config['language'].']'.$obj.
@@ -820,6 +820,18 @@ function qtranxf_json_encode($o){
 function qtranxf_config_add_form( &$page_config, $nm){
 	if(!isset($page_config['forms'][$nm])) $page_config['forms'][$nm] = array('fields' => array());
 	else if(!isset($page_config['forms'][$nm]['fields'])) $page_config['forms'][$nm]['fields'] = array();
+}
+
+/**
+ * @since 3.4.1
+ * check the WP Nonce - OK if POST is empty
+ * @link https://codex.wordpress.org/Function_Reference/wp_nonce_field#Examples
+ * @param  string $my_action   Name specified when generating the nonce
+ * @param  string $nonce_field Form input name for the nonce
+ * @return boolean             True if the nonce is ok
+ */
+function qtranxf_verify_nonce($my_action, $nonce_field = '_wpnonce') {
+	return empty( $_POST ) || check_admin_referer( $my_action, $nonce_field );
 }
 
 add_filter('manage_language_columns', 'qtranxf_language_columns');

--- a/admin/qtx_configuration.php
+++ b/admin/qtx_configuration.php
@@ -163,7 +163,7 @@ function qtranxf_conf() {
 <h2><?php _e('Edit Language', 'qtranslate') ?></h2>
 <form action="" method="post" id="qtranxs-edit-language">
 <?php qtranxf_language_form() ?>
-<p class="submit"><input type="submit" name="submit" value="<?php _e('Save Changes &raquo;', 'qtranslate') ?>" /></p>
+<p class="submit"><input type="submit" name="submit" class="button-primary" value="<?php _e('Save Changes &raquo;', 'qtranslate') ?>" /></p>
 </form>
 <p class="qtranxs_notes"><a href="<?php echo admin_url('options-general.php?page=qtranslate-x#languages') ?>"><?php _e('back to configuration page', 'qtranslate') ?></a></p>
 <?php
@@ -652,7 +652,7 @@ echo ' '; printf(__('Please, read %sIntegration Guide%s for more information.', 
 <?php
 	wp_nonce_field($my_nonce_action); // Prevent CSRF
 	qtranxf_language_form();
-	qtranxf_admin_section_end('languages',__('Add Language &raquo;', 'qtranslate'), null);
+	qtranxf_admin_section_end('languages',__('Add Language &raquo;', 'qtranslate'));
 ?>
 </form></div></div></div></div></div>
 <?php } ?>

--- a/admin/qtx_configuration.php
+++ b/admin/qtx_configuration.php
@@ -650,6 +650,7 @@ echo ' '; printf(__('Please, read %sIntegration Guide%s for more information.', 
 <h3><?php _e('Add Language', 'qtranslate') ?></h3>
 <form name="addlang" id="addlang" method="post" class="add:the-list: validate">
 <?php
+	wp_nonce_field($my_nonce_action); // Prevent CSRF
 	qtranxf_language_form();
 	qtranxf_admin_section_end('languages',__('Add Language &raquo;', 'qtranslate'), null);
 ?>

--- a/admin/qtx_configuration.php
+++ b/admin/qtx_configuration.php
@@ -28,7 +28,7 @@ function qtranxf_language_form() {
 </div>
 <div class="form-field">
 	<label for="language_flag"><?php _e('Flag', 'qtranslate') ?></label>
-	<?php 
+	<?php
 	$files = array();
 	$flag_dir = trailingslashit(WP_CONTENT_DIR).$q_config['flag_location'];
 	if($dir_handle = @opendir($flag_dir)) {
@@ -166,7 +166,13 @@ function qtranxf_conf() {
 <p class="submit"><input type="submit" name="submit" value="<?php _e('Save Changes &raquo;', 'qtranslate') ?>" /></p>
 </form>
 <p class="qtranxs_notes"><a href="<?php echo admin_url('options-general.php?page=qtranslate-x#languages') ?>"><?php _e('back to configuration page', 'qtranslate') ?></a></p>
-<?php } else { ?>
+<?php
+	} else {
+		$my_nonce_action = 'qtranslate-x_configuration_form';
+		if ( ! qtranxf_verify_nonce( $my_nonce_action ) ) {
+			return;
+		}
+?>
 <h2><?php _e('Language Management (qTranslate Configuration)', 'qtranslate') ?></h2>
 <p class="qtranxs_heading" style="font-size: small"><?php printf(__('For help on how to configure qTranslate correctly, take a look at the <a href="%1$s">qTranslate FAQ</a> and the <a href="%2$s">Support Forum</a>.', 'qtranslate')
   , 'https://qtranslatexteam.wordpress.com/faq/'
@@ -204,6 +210,7 @@ echo ' '; printf(__('Please, read %sIntegration Guide%s for more information.', 
 	echo '</h2>'.PHP_EOL;
 ?>
 	<form id="qtranxs-configuration-form" action="<?php echo $clean_uri;?>" method="post">
+	<?php wp_nonce_field($my_nonce_action); // Prevent CSRF ?>
 	<div class="tabs-content"><?php //<!-- tabs-container --> ?>
 	<?php qtranxf_admin_section_start('general');
 		$permalink_is_query = qtranxf_is_permalink_structure_query();
@@ -314,7 +321,7 @@ echo ' '; printf(__('Please, read %sIntegration Guide%s for more information.', 
 				<td>
 					<label for="post_types"><?php _e('Post types enabled for translation:', 'qtranslate') ?></label><p>
 					<?php
-						$post_types = get_post_types(); 
+						$post_types = get_post_types();
 						foreach ( $post_types as $post_type ) {
 							if(!qtranxf_post_type_optional($post_type)) continue;
 							$post_type_off = isset($q_config['post_type_excluded']) && in_array($post_type,$q_config['post_type_excluded']);

--- a/qtranslate.php
+++ b/qtranslate.php
@@ -3,7 +3,7 @@
 Plugin Name: qTranslate-X
 Plugin URI: http://wordpress.org/plugins/qtranslate-x/
 Description: Adds user-friendly and database-friendly multilingual content support.
-Version: 3.4.4
+Version: 3.4.6
 Author: qTranslate Team
 Author URI: http://qtranslatexteam.wordpress.com/about
 Tags: multilingual, multi, language, admin, tinymce, Polyglot, bilingual, widget, switcher, professional, human, translation, service, qTranslate, zTranslate, mqTranslate, qTranslate Plus, WPML
@@ -64,7 +64,7 @@ GitHub Branch: master
 	pt(pt_PT) by netolazaro, Pedro Mendonça
 	pb(pt_BR) by Pedro Mendonça
 	ro hu by Jani Monoses
-	sv by bear3556, johdah 
+	sv by bear3556, johdah
 	vi by hathhai
 	zh(zh_CN) by Junyan Chen
 	ua(uk) Vadym Volos (https://google.com/+VadymVolos https://wordpress.org/support/profile/vadim-v)

--- a/qtranslate_widget.php
+++ b/qtranslate_widget.php
@@ -29,7 +29,7 @@ class qTranslateXWidget extends WP_Widget {
 
 	function qTranslateXWidget() {
 		$widget_ops = array('classname' => 'qtranxs_widget', 'description' => __('Allows your visitors to choose a Language.', 'qtranslate') );
-		$this->WP_Widget('qtranslate', __('qTranslate Language Chooser', 'qtranslate'), $widget_ops);
+		parent::__construct('qtranslate', __('qTranslate Language Chooser', 'qtranslate'), $widget_ops);
 	}
 
 	function widget($args, $instance) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: johnclause, chineseleper, Vavooon, grafcom
 Tags: multilingual, language, admin, tinymce, bilingual, widget, switcher, i18n, l10n, multilanguage, translation
 Requires at least: 3.9
 Tested up to: 4.3
-Stable tag: 3.4.5
+Stable tag: 3.4.6
 License: GPLv3 or later
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=QEXEK3HX8AR6U
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: johnclause, chineseleper, Vavooon, grafcom
 Tags: multilingual, language, admin, tinymce, bilingual, widget, switcher, i18n, l10n, multilanguage, translation
 Requires at least: 3.9
 Tested up to: 4.3
-Stable tag: 3.4.4
+Stable tag: 3.4.5
 License: GPLv3 or later
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=QEXEK3HX8AR6U
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -111,7 +111,7 @@ Read [migration instructions](https://qtranslatexteam.wordpress.com/migration/ "
 
 ### 3.4.2 stable ###
 * Fix: i18n configuration loading on the first installation, [WP Topic](https://wordpress.org/support/topic/update-that-makes-one-see-the-site-only-a-blank-page).
-* Fix for qtranxf_updateGettextDatabases. 
+* Fix for qtranxf_updateGettextDatabases.
 
 ### 3.4.1 stable ###
 * Fix: i18n configuration loading for integrated plugins.


### PR DESCRIPTION
The WordPress vulnerability seems valid. I have added in a nonce to prevent CSRF attacks. I've currently only tested on my local Windows machine in Firefox.

1. I've tested using the attack suggested by WordPress of POSTing a form with buried Javascript - this would work on the v3.4.4 plugin as it would run the Javascript
2. Now the plugin will give the standard 'Are you sure you want to do this?' if the form is POSTed without the nonce
3. I've tested that changing the default language and re-submitting still works correctly
4. I've tested that the Edit Language form still works (this doesn't have a nonce on it as POSTed values aren't inserted)
5. I've tested that the Add Language form will generate errors correctly
6. I've tested that a Language can be successfully added
7. I made a tweak to the submit button classes for the Add / Edit language forms to put the current WordPress submit button styles on them
8. I've updated the version numbers to 3.4.5 and created a tag