### PR TITLE
Update widget construction for Wordpress 4.3.0

### DIFF
--- a/qtranslate_widget.php
+++ b/qtranslate_widget.php
@@ -29,7 +29,7 @@ class qTranslateXWidget extends WP_Widget {
 
 	function qTranslateXWidget() {
 		$widget_ops = array('classname' => 'qtranxs_widget', 'description' => __('Allows your visitors to choose a Language.', 'qtranslate') );
-		$this->WP_Widget('qtranslate', __('qTranslate Language Chooser', 'qtranslate'), $widget_ops);
+		$this->__construct('qtranslate', __('qTranslate Language Chooser', 'qtranslate'), $widget_ops);
 	}
 
 	function widget($args, $instance) {


### PR DESCRIPTION
With debug enabled, this new message appears since latest update to Wordpress 4.3.0

Notice: The called constructor method for WP_Widget is deprecated since version 4.3.0! Use
__construct()
instead. in D:\Software\XAMPP\htdocs\wp\wp-includes\functions.php on line 3457

Just change `$this->WP_Widget` to `$this->__construct`