### PR TITLE
bug url comparaison : origin url and target url

### DIFF
--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -70,7 +70,7 @@ function qtranxf_init_language() {
 	if( $q_config['url_info']['doing_front_end'] && qtranxf_can_redirect() ){
 		$lang = $q_config['language'];
 		$url_orig = $url_info['scheme'].'://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
-		$url_lang = qtranxf_convertURL('',$lang);//uses $q_config['url_info'] and caches information, which will be needed later anyway.
+		$url_lang = qtranxf_convertURL($url_orig,$lang);//uses $q_config['url_info'] and caches information, which will be needed later anyway.
 		if(!isset($url_info['doredirect']) && $url_orig != $url_lang){
 			$url_info['doredirect'] = '$url_orig != $url_lang';
 		}


### PR DESCRIPTION
We are using question2answer with wordpress and qtranslatex  3.4.6.2.

We are using rewrite rules on question2answer  :

```
RewriteCond %{REQUEST_FILENAME} !-f
RewriteCond %{REQUEST_FILENAME} !-d
RewriteRule ^.*$ index.php?qa-rewrite=$0&%{QUERY_STRING} [L]
```

We have an infinity of redirection on question2answer when qtranslatex is activated .

The problem is on these values :
$url_orig = https://www.exemple.com/fluks/qa/search?q=frfr
$url_lang =  https://www.exemple.com/fluks/qa/search?qa-rewrite=search&q=frfr

We solved this problem with this modification
