### PR TITLE
Added a "force_markers" option so qTranslate always keeps all language markers

### DIFF
--- a/admin/qtx_configuration.php
+++ b/admin/qtx_configuration.php
@@ -362,6 +362,13 @@ echo ' '; printf(__('Please, read %sIntegration Guide%s for more information.', 
 				</td>
 			</tr>
 			<tr valign="top">
+				<th scope="row"><?php _e('Translation saving', 'qtranslate') ?></th>
+				<td>
+					<label for="force_markers"><input type="checkbox" name="force_markers" id="force_markers" value="1"<?php checked($q_config['force_markers']); ?> /> <?php echo __('Always keep language markers', 'qtranslate') ?></label>
+					<p class="qtranxs_notes"><?php echo __('By default qTranslate-X removes the language markers (e.g. "[:en]") if all languages are identical for a certain field. With this option, you can force the language markers to be kept, which in some cases might be necessary to prevent sorting problems.', 'qtranslate') ?></p>
+				</td>
+			</tr>
+			<tr valign="top">
 				<th scope="row"><?php _e('Flag Image Path', 'qtranslate') ?></th>
 				<td>
 					<?php echo trailingslashit(content_url()) ?><input type="text" name="flag_location" id="flag_location" value="<?php echo $q_config['flag_location']; ?>" style="width:100%"/>

--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -1241,7 +1241,19 @@ function qtranxf_split_languages($blocks) {
 //	qtranxf_join_c($texts);
 //}
 
+/**
+ * Check if all the given translations are identical.
+ * If yes, reduce them to a single text.
+ * Otherwise, return null.
+ * This behaviour can be deactivated using $q_config['force_markers']
+ * 
+ * @param $texts
+ * @return null|string
+ */
 function qtranxf_allthesame($texts) {
+	global $q_config;
+	if($q_config['force_markers']) return null;
+
 	$text = null;
 	//take first not empty
 	foreach($texts as $lang => $t){

--- a/qtranslate_options.php
+++ b/qtranslate_options.php
@@ -77,6 +77,7 @@ function qtranxf_set_default_options(&$ops)
 		'hide_default_language' => true,// hide language tag for default language in urls
 		'use_secure_cookie' => false,
 		'header_css_on' => true,
+		'force_markers' => false,// always keep language markers, even if the translations are all identical
 	);
 
 	//single line options


### PR DESCRIPTION
By default qTranslate-X removes the language markers (e.g. "[:en]") if all languages are identical for a certain field. With this option, you can force the language markers to be kept, which in some cases might be necessary to prevent sorting problems.

I also added a small documentation to the function I modified.