### PR TITLE
Make the message with the list of alternatives languages optional

### DIFF
--- a/admin/qtx_configuration.php
+++ b/admin/qtx_configuration.php
@@ -322,8 +322,11 @@ echo ' '; printf(__('Please, read %sIntegration Guide%s for more information.', 
 					<br/>
 					<p class="qtranxs_notes"><?php _e('This is relevant to all fields other than the main content of posts and pages. Such untranslated fields are always shown in an alternative available language, and will be prefixed with the language name in parentheses, if this option is on.', 'qtranslate') ?></p>
 					<br/>
+					<label for="show_alternative_content_message"><input type="checkbox" name="show_alternative_content_message" id="show_alternative_content_message" value="1"<?php checked($q_config['show_alternative_content_message']) ?>/> <?php _e('When content is displayed in an alternative language, show an explanatory message.', 'qtranslate') ?></label>
+					<p class="qtranxs_notes"><?php printf(__('If this option is on, a message with a list of other available languages is displayed when a page or a post with an untranslated content is viewed. The languages are ordered as defined by option "%s".', 'qtranslate'), __('Default Language / Order', 'qtranslate')) ?></p>
+					<br/>
 					<label for="show_alternative_content"><input type="checkbox" name="show_alternative_content" id="show_alternative_content" value="1"<?php checked($q_config['show_alternative_content']) ?>/> <?php _e('Show content in an alternative language when translation is not available for the selected language.', 'qtranslate') ?></label>
-					<p class="qtranxs_notes"><?php printf(__('When a page or a post with an untranslated content is viewed, a message with a list of other available languages is displayed, in which languages are ordered as defined by option "%s". If this option is on, then the content of the first available language will also be shown, instead of the expected language, for the sake of user convenience.', 'qtranslate'), __('Default Language / Order', 'qtranslate')) ?></p>
+					<p class="qtranxs_notes"><?php echo __('If this option is on, then the content of the first available language will also be shown, instead of the expected language, for the sake of user convenience.', 'qtranslate') ?></p>
 				</td>
 			</tr>
 			<tr valign="top">

--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -1466,7 +1466,7 @@ function qtranxf_use_content($lang, $content, $available_langs, $show_available=
 	$alt_content = $content[$alt_lang];
 	$alt_lang_is_default = $alt_lang == $q_config['default_language'];
 
-	if(!$show_available){
+	if(!$show_available || !$q_config['show_alternative_content_message']){
 		if ($q_config['show_displayed_language_prefix'])
 			return '('.$q_config['language_name'][$alt_lang].') '.$alt_content;
 		else

--- a/qtranslate_options.php
+++ b/qtranslate_options.php
@@ -73,6 +73,7 @@ function qtranxf_set_default_options(&$ops)
 		'detect_browser_language' => true,// enables browser language detection
 		'hide_untranslated' => false,// hide pages without content
 		'show_displayed_language_prefix' => true,
+		'show_alternative_content_message' => true,
 		'show_alternative_content' => false,
 		'hide_default_language' => true,// hide language tag for default language in urls
 		'use_secure_cookie' => false,


### PR DESCRIPTION
When a post has not been translated to the current language, an explanatory message ("Sorry, this entry is only available in xxxx. For the sake of viewer convenience, the content is shown below in the alternative language. ...") is displayed. This patch makes that message optional. By default, the message is still displayed after this patch because by default the new option is checked.

For many of our customers, the message is irrelevant because their visitors do not really care what language a post is in. Until now, we have worked with additional custom filters to hide the message, but having it as an option might be useful to other plugin users as well.
