### PR TITLE
Escape regular expressions when matching page

### DIFF
--- a/qtranslate_utils.php
+++ b/qtranslate_utils.php
@@ -639,8 +639,10 @@ function qtranxf_match_page($cfg, $url_path, $url_query, $d){
 	if(!isset($cfg['pages']))
 		return true;
 	foreach($cfg['pages'] as $page => $query){
+		$page = str_replace($d, '\\'.$d, $page);
 		if( preg_match($d.$page.$d,$url_path) !== 1 ) continue;
 		//qtranxf_dbg_log('qtranxf_match_page: preg_match('.$d.$query.$d.', '.$url_query.')');
+		$query = str_replace($d, '\\'.$d, $query);
 		if( empty($query) || preg_match($d.$query.$d,$url_query) === 1 )
 			return true;
 	}


### PR DESCRIPTION
If the delimiter specified by `$d` is in the regular expression for `$page` or `$query` then `preg_match` will fail with an unknown modifier warning. For example:

```php
add_filter('i18n_admin_config', function($config){
	$config['custom-page'] = [
		'pages' => [
			'edit.php' => '^(?!.*page=[^=&]+).*$'
		]
	];
	return $config;
});
```

In this example the query regular expression contains `!` which is the default for $d as a result this will fail with an unknown modifier warning because the `!` causes the regular expression to end prematurely and cause PHP to interpret everything after it as regular expression modifiers.