### PR TITLE
Avoid redirect request cache

### DIFF
--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -76,6 +76,7 @@ function qtranxf_init_language() {
 			$target = apply_filters('qtranslate_language_detect_redirect', $url_lang, $url_orig, $url_info);
 			//qtranxf_dbg_log('qtranxf_init_language: doredirect to '.$lang.PHP_EOL .'urlorg:'.$url_orig.PHP_EOL .'target:'.$target.PHP_EOL .'url_info: ',$url_info);
 			if($target!==false && $target != $url_orig){
+				nocache_headers();
 				wp_redirect($target);
 				//header('Location: '.$target);
 				exit();


### PR DESCRIPTION
This correct problems when using reverse proxy cache, wich caches the request and you can not change the language until the cache expires.