### PR TITLE
Update qtranslate_core.php

### DIFF
--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -324,7 +324,9 @@ function qtranxf_parse_language_info(&$url_info, $link=false) {
 		//}
 	}else if(isset($url_info['lang_url'])){
 		$lang = $url_info['lang_url'];
-		if($q_config['hide_default_language'] && $lang == $q_config['default_language']) $doredirect=true;
+		if($q_config['hide_default_language'] && $lang == $q_config['default_language']){
+			$doredirect = ($url_info['wp-path']=='/' ? false : true);
+		}
 	}
 
 	if($lang) $url_info['language'] = $lang;

--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -242,11 +242,16 @@ function qtranxf_parse_language_info(&$url_info, $link=false) {
 					if($lang){
 						$url_info['lang_url'] = $lang;
 						$url_info['wp-path'] = substr($url_info['wp-path'],3);
-						$url_info['doing_front_end'] = true;
-						if(WP_DEBUG){
-							$url_info['url_mode'] = 'pre-path';
-						}
 					}
+				}else{
+					$lang = $q_config['default_language'];
+					if($lang){
+						$url_info['lang_url'] = $lang;
+					}
+				}
+				$url_info['doing_front_end'] = true;
+				if(WP_DEBUG){
+					$url_info['url_mode'] = 'pre-path';
 				}
 				//}
 				break;


### PR DESCRIPTION
Hello!
It's very simle fix.
Situation:
Option "pre path mode"
Option "hide language url for default language" 
Plugin qtranslate-slug
Two language: en,de (en is default)
One page with different slug: for en - /buy/, for de - /kaufen/

If we open:
site.com/de/kaufen/ - it's work. qTranslate-x detect language and write value to cookie

But if we after than direct open link like this: site.com/buy/ we got 404 error, becouse qTranslate-x get cookie value (de) and redirect us to site.com/de/buy/

This fix is working for "pre path mode", and detect in "wp-path" language code. If "preg_match" return false - it's mean default language needed and set $lang default language.