### PR TITLE
update qtranslatexwidget constructor to php-5

### DIFF
--- a/qtranslate_widget.php
+++ b/qtranslate_widget.php
@@ -29,7 +29,7 @@ transition: 1s ease opacity;
 
 class qTranslateXWidget extends WP_Widget {
 
-	function qTranslateXWidget() {
+	function __construct() {
 		$widget_ops = array('classname' => 'qtranxs_widget', 'description' => __('Allows your visitors to choose a Language.', 'qtranslate') );
 		parent::__construct('qtranslate', __('qTranslate Language Chooser', 'qtranslate'), $widget_ops);
 	}


### PR DESCRIPTION
Using php 7.0 i get a deprecationwarning for using old-style constructors:
```
*Deprecated*:  Methods with the same name as their class will not be constructors in a future version of PHP; qTranslateXWidget has a deprecated constructor in *[.../]qtranslate-x/qtranslate_widget.php* on line *30*
```

php4-constructors are deprecated in favour of php5 "__construct()"