### PR TITLE
Removed unnecessary trimming

### DIFF
--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -1085,10 +1085,6 @@ function qtranxf_split_blocks($blocks, &$found = array()) {
 			break;
 		}
 	}
-	//it gets trimmed later in qtranxf_use() anyway, better to do it here
-	foreach($result as $lang => $text){
-		$result[$lang]=trim($text);
-	}
 	return $result;
 }
 


### PR DESCRIPTION
I make this change to my install after every update, it might be useful for others as well. 

Contrary to the comment, qtranxf_use() doesn't trim the content, so this change allows you to keep your whitespace at the beginning/end of translation strings. 
