### PR TITLE
Hidden default lang pre-path cookies problem fix

### DIFF
--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -389,6 +389,7 @@ function qtranxf_detect_language_front(&$url_info) {
 	){
 		$url_info['doredirect']='language needs to be shown in url';
 	}
+	if(isset($url_info['doredirect']) && $q_config['hide_default_language']) $lang = $q_config['default_language'];
 	return $lang;
 }
 


### PR DESCRIPTION
Dear qtranslate-x team. I, as many people (https://wordpress.org/support/topic/how-to-disable-the-qtrans_front_language-cookie) was having problems with qtranslate-x set in pre-path mode and hidden default language. Browsing my site was trouble cause event though language switcher worked just fine, browsing to the default language with browser's back button or even writting down the url didn't work. I schemed the code and after some trial and errors added that line that seems to fix it. It can give other problems though, I would like you to take a look at it. Also I am 100% sire it is NOT a problem of qtranslate-slug. My site is this if you wanna check it: https://xnet-x.net/ hugs
