### PR TITLE
Check for disable_client_cookies setting when determining lang

### DIFF
--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -364,7 +364,9 @@ function qtranxf_detect_language_front(&$url_info) {
 	global $q_config;
 	//assert($url_info['doing_front_end']);
 	while(true){
-		if( isset($_COOKIE[QTX_COOKIE_NAME_FRONT]) ){
+		if( isset($_COOKIE[QTX_COOKIE_NAME_FRONT])
+			&& !$q_config['disable_client_cookies']
+		){
 			$cs=null;
 			$lang=qtranxf_resolveLangCase($_COOKIE[QTX_COOKIE_NAME_FRONT],$cs);
 			$url_info['lang_cookie_front'] = $lang;


### PR DESCRIPTION
Currently, if you disable_client_cookies in the settings but some of your user's browsers still have cookies stored, the setting will not be respected and they will be redirected according to the cookie.  Adding a condition to check for the disable_client_cookies setting.
