### PR TITLE
Stop forcing suppress_filters to false on WP_Query

### DIFF
--- a/qtranslate_frontend.php
+++ b/qtranslate_frontend.php
@@ -551,7 +551,6 @@ function qtranxf_pre_get_posts( &$query ) {//WP_Query
 				default: break;
 			}
 	}
-	$query->query_vars['suppress_filters'] = false;
 }
 add_action( 'pre_get_posts', 'qtranxf_pre_get_posts', 99 );
 


### PR DESCRIPTION
The `qtranxf_pre_get_posts` action forces `$query->query_vars['suppress_filters'] = false;`. This way   on the front end no queries can be performed using WP_Query where the `suppress_filters` argument is set to true (unless one removes the action altogether before performing a query with WP_Query). 
