### PR TITLE
Fix for blocking rest api requests

### DIFF
--- a/qtranslate_core.php
+++ b/qtranslate_core.php
@@ -82,7 +82,7 @@ function qtranxf_init_language() {
 			 */
 			$target = apply_filters('qtranslate_language_detect_redirect', $url_lang, $url_orig, $url_info);
 			//qtranxf_dbg_log('qtranxf_init_language: doredirect to '.$lang.PHP_EOL .'urlorg:'.$url_orig.PHP_EOL .'target:'.$target.PHP_EOL .'url_info: ',$url_info);
-			if($target!==false && $target != $url_orig){
+			if( $target !== false && $target != $url_orig && ! is_rest_api_request( $url_orig ) ) {
 				nocache_headers();
 				wp_redirect($target);
 				//header('Location: '.$target);
@@ -1478,3 +1478,16 @@ function qtranxf_optionFilter($do='enable') {//do we need it?
 	}
 }
 */
+/**
+ * Checks whether the original url is a REST API request or no
+ *
+ * @param $url_orig
+ *
+ * @return boolean Returns true if the request is for rest api, else return false
+ */
+function is_rest_api_request( $url_orig ) {
+	if ( false !== strpos( $url_orig, 'wp-json' ) ) {
+		return true;
+	}
+	return false;
+}


### PR DESCRIPTION
Hi John Clause,

I'm Venkat and working for UpdraftPlus. One of our plugin (we recently acquired it) Easy Updates Manager uses REST API and React for dashboard settings. Since your plugin redirects incoming requests (to append language to url), it redirects REST API calls as well. Even though it works for GET calls, POST calls gives a 404.

We have solved it using your filter `qtranslate_language_detect_redirect`, but since rest api is in core, I think you too don't want to redirect the rest api url.

This branch has fix for blocking rest api requests. If you could review, merge and release a plugin update, It is much appreciated. Thanks in advance.

Regards,
Venkat