### PR TITLE
PHP7.4 continue is deprecated

### DIFF
--- a/qtranslate_frontend.php
+++ b/qtranslate_frontend.php
@@ -493,7 +493,7 @@ function qtranxf_translate_post($post,$lang) {
 			case 'post_mime_type':
 			case 'comment_count':
 			case 'filter':
-				continue;
+				break;
 			//known to translate
 			case 'post_content': $post->$key = qtranxf_use_language($lang, $txt, true); break;
 			case 'post_title':


### PR DESCRIPTION
and the extension throw a warning on this line "496"
change continue to break
continue is no longer supported since php 7.